### PR TITLE
Fix: video comments fetching returns empty results

### DIFF
--- a/bili_cli/client.py
+++ b/bili_cli/client.py
@@ -287,21 +287,45 @@ async def get_rank_videos(day: int = 3) -> dict[str, Any]:
 async def get_video_comments(
     bvid: str, page: int = 1, credential: Credential | None = None
 ) -> dict[str, Any]:
-    """Fetch video comments."""
+    """Fetch video comments.
+
+    Uses the direct Bilibili API endpoint instead of the bilibili-api-python
+    comment module, which has compatibility issues with the latest API.
+    """
     v = video.Video(bvid=bvid, credential=credential)
     info = await _call_api("获取视频信息", v.get_info())
     aid = info.get("aid")
     if aid is None:
         raise BiliError("获取视频评论: 视频信息缺少 aid")
-    return await _call_api(
-        "获取视频评论",
-        comment.get_comments(
-            oid=aid,
-            type_=comment.CommentResourceType.VIDEO,
-            page_index=page,
-            credential=credential,
-        ),
-    )
+
+    # Use direct API call instead of comment.get_comments to fix compatibility
+    api_url = f"https://api.bilibili.com/x/v2/reply"
+    params = {
+        "oid": aid,
+        "type": 1,
+        "pn": page,
+        "ps": 20,
+        "sort": 2,  # Sort by hot/popular
+    }
+
+    timeout = aiohttp.ClientTimeout(total=30)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        try:
+            async with session.get(api_url, params=params, headers={
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                "Referer": f"https://www.bilibili.com/video/{bvid}/",
+                "Accept": "application/json, text/plain, */*",
+                "Accept-Language": "zh-CN,zh;q=0.9",
+            }) as resp:
+                resp.raise_for_status()
+                data = await resp.json()
+
+                if data.get("code") != 0:
+                    raise BiliError(f"获取视频评论: [{data.get('code')}] {data.get('message', 'Unknown error')}")
+
+                return data["data"]
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            raise NetworkError(f"获取视频评论失败: {e}") from e
 
 
 async def get_video_ai_conclusion(


### PR DESCRIPTION
## Problem

The `bili video <bv> --comments` command was returning "暂无评论" (no comments) even when the video actually has comments.

## Root Cause

The `comment.get_comments` function from `bilibili-api-python` library has compatibility issues with the latest Bilibili API, causing it to return empty results.

## Solution

Replace the library function with a direct HTTP API call to the Bilibili endpoint:
- URL: `https://api.bilibili.com/x/v2/reply`
- Parameters: oid (aid), type=1 (video), pn (page), ps=20, sort=2 (hot)
- Proper browser-like headers including User-Agent and Referer

## Changes

- Modified `bili_cli/client.py`: Replaced `comment.get_comments` call with direct aiohttp request
- Added proper error handling for network and API errors
- Added detailed docstring explaining the workaround

## Testing

Tested with: `BV1ABcsztEcY` (影视飓风的短剧出海视频)
- Before fix: Returns "暂无评论"
- After fix: Successfully returns 3 hot comments

```python
async def test():
    data = await get_video_comments('BV1ABcsztEcY')
    replies = data.get('replies', [])
    print(f'Success: {len(replies)} comments')  # Output: Success: 3 comments
```

## Related Issues

This PR fixes the comment fetching functionality that was reported to not work properly.
