### PR TITLE
feat: 添加带时间线的字幕功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ bili whoami                    # Detailed profile (level, coins, followers)
 
 # Videos
 bili video BV1ABcsztEcY                 # Video details
-bili video BV1ABcsztEcY --subtitle      # With subtitles
+bili video BV1ABcsztEcY --subtitle                 # With subtitles (plain text)
+bili video BV1ABcsztEcY --subtitle-timeline        # With timeline
+bili video BV1ABcsztEcY -st --subtitle-format srt  # Export as SRT format
 bili video BV1ABcsztEcY --ai            # AI summary
 bili video BV1ABcsztEcY --comments      # Top comments
 bili video BV1ABcsztEcY --related       # Related videos
@@ -204,7 +206,9 @@ bili whoami                    # 查看个人信息（等级、硬币、粉丝�
 
 # 视频
 bili video BV1ABcsztEcY                 # 视频详情
-bili video BV1ABcsztEcY --subtitle      # 显示字幕
+bili video BV1ABcsztEcY --subtitle                 # 显示字幕（纯文本）
+bili video BV1ABcsztEcY --subtitle-timeline        # 显示带时间线的字幕
+bili video BV1ABcsztEcY -st --subtitle-format srt  # 导出为 SRT 格式
 bili video BV1ABcsztEcY --ai            # AI 总结
 bili video BV1ABcsztEcY --comments      # 热门评论
 bili video BV1ABcsztEcY --related       # 相关推荐

--- a/SKILL.md
+++ b/SKILL.md
@@ -49,7 +49,9 @@ bili video BV1ABcsztEcY
 bili video https://www.bilibili.com/video/BV1ABcsztEcY
 
 # Options
-bili video BV1ABcsztEcY --subtitle      # Show subtitles (AI or uploaded)
+bili video BV1ABcsztEcY --subtitle            # Show subtitles (plain text)
+bili video BV1ABcsztEcY --subtitle-timeline   # Show subtitles with timestamps
+bili video BV1ABcsztEcY -st --subtitle-format srt  # Export as SRT format
 bili video BV1ABcsztEcY --ai            # Show B站 AI summary
 bili video BV1ABcsztEcY --comments      # Show top comments
 bili video BV1ABcsztEcY --related       # Show related videos

--- a/bili_cli/client.py
+++ b/bili_cli/client.py
@@ -86,6 +86,57 @@ async def get_video_info(bvid: str, credential: Credential | None = None) -> dic
     return await _call_api("获取视频信息", v.get_info())
 
 
+
+def format_subtitle_timeline(raw: list, format: str = "timeline") -> str:
+    """Format subtitle with timeline.
+    
+    Args:
+        raw: List of subtitle items with 'content', 'from', 'to' fields
+        format: Output format - "timeline" (human readable) or "srt"
+    
+    Returns:
+        Formatted subtitle string with timestamps
+    """
+    if not raw:
+        return ""
+    
+    if format == "srt":
+        lines = []
+        for i, item in enumerate(raw, 1):
+            content = item.get("content", "")
+            from_sec = item.get("from", 0)
+            to_sec = item.get("to", 0)
+            lines.append(str(i))
+            lines.append(f"{_format_srt_time(from_sec)} --> {_format_srt_time(to_sec)}")
+            lines.append(content)
+            lines.append("")
+        return "\n".join(lines)
+    else:
+        # timeline format: [MM:SS.mmm --> MM:SS.mmm] content
+        lines = []
+        for item in raw:
+            content = item.get("content", "")
+            from_sec = item.get("from", 0)
+            to_sec = item.get("to", 0)
+            lines.append(f"[{_format_time(from_sec)} --> {_format_time(to_sec)}] {content}")
+        return "\n".join(lines)
+
+
+def _format_time(seconds: float) -> str:
+    """Format seconds as MM:SS.mmm"""
+    mins = int(seconds // 60)
+    secs = seconds % 60
+    return f"{mins:02d}:{secs:06.3f}"
+
+
+def _format_srt_time(seconds: float) -> str:
+    """Format seconds as SRT time: HH:MM:SS,mmm"""
+    hours = int(seconds // 3600)
+    mins = int((seconds % 3600) // 60)
+    secs = seconds % 60
+    return f"{hours:02d}:{mins:02d}:{secs:06.3f}".replace(".", ",")
+
+
 async def get_video_subtitle(
     bvid: str, credential: Credential | None = None
 ) -> tuple[str, list]:

--- a/bili_cli/commands/video.py
+++ b/bili_cli/commands/video.py
@@ -12,12 +12,14 @@ from . import common
 
 @click.command()
 @click.argument("bv_or_url")
-@click.option("--subtitle", "-s", is_flag=True, help="显示字幕内容。")
+@click.option("--subtitle", "-s", is_flag=True, help="显示字幕内容（纯文本）。")
+@click.option("--subtitle-timeline", "-st", is_flag=True, help="显示带时间线的字幕。")
+@click.option("--subtitle-format", type=click.Choice(["timeline", "srt"]), default="timeline", help="字幕格式：timeline（人类可读）或 srt。")
 @click.option("--comments", "-c", is_flag=True, help="显示评论。")
 @click.option("--ai", is_flag=True, help="显示 AI 总结。")
 @click.option("--related", "-r", is_flag=True, help="显示相关推荐视频。")
 @click.option("--json", "as_json", is_flag=True, help="输出原始 JSON。")
-def video(bv_or_url: str, subtitle: bool, comments: bool, ai: bool, related: bool, as_json: bool):
+def video(bv_or_url: str, subtitle: bool, subtitle_timeline: bool, subtitle_format: str, comments: bool, ai: bool, related: bool, as_json: bool):
     """查看视频详情。
 
     BV_OR_URL 可以是 BV 号（如 BV1xxx）或完整 URL。
@@ -62,16 +64,23 @@ def video(bv_or_url: str, subtitle: bool, comments: bool, ai: bool, related: boo
 
     common.console.print(table)
 
-    if subtitle:
+    if subtitle or subtitle_timeline:
         common.console.print("\n[bold]📝 字幕内容:[/bold]\n")
         sub_data = common.run_optional(
             client.get_video_subtitle(bvid, credential=cred),
             "获取字幕失败",
         )
         if sub_data is not None:
-            sub_text, _ = sub_data
-            if sub_text:
-                common.console.print(sub_text)
+            sub_text, raw = sub_data
+            # Determine content to display
+            display_content = ""
+            if subtitle_timeline and raw:
+                display_content = client.format_subtitle_timeline(raw, format=subtitle_format)
+            elif subtitle:
+                display_content = sub_text
+            
+            if display_content:
+                common.console.print(display_content)
             else:
                 common.console.print("[yellow]⚠️  无字幕（可能需要登录或视频无字幕）[/yellow]")
 

--- a/tests/test_subtitle.py
+++ b/tests/test_subtitle.py
@@ -1,0 +1,168 @@
+"""Tests for subtitle formatting functions."""
+
+import pytest
+from bili_cli.client import _format_time, _format_srt_time, format_subtitle_timeline
+
+
+class TestFormatTime:
+    """Tests for _format_time function (MM:SS.mmm format)."""
+
+    def test_zero_seconds(self):
+        assert _format_time(0.0) == "00:00.000"
+
+    def test_simple_seconds(self):
+        assert _format_time(2.5) == "00:02.500"
+        assert _format_time(5.0) == "00:05.000"
+
+    def test_one_minute(self):
+        assert _format_time(60.0) == "01:00.000"
+        assert _format_time(65.333) == "01:05.333"
+
+    def test_multiple_minutes(self):
+        assert _format_time(125.789) == "02:05.789"
+        assert _format_time(300.0) == "05:00.000"
+
+    def test_milliseconds_precision(self):
+        assert _format_time(1.001) == "00:01.001"
+        assert _format_time(1.999) == "00:01.999"
+
+
+class TestFormatSrtTime:
+    """Tests for _format_srt_time function (HH:MM:SS,mmm format)."""
+
+    def test_zero_seconds(self):
+        assert _format_srt_time(0.0) == "00:00:00,000"
+
+    def test_simple_seconds(self):
+        assert _format_srt_time(2.5) == "00:00:02,500"
+        assert _format_srt_time(5.0) == "00:00:05,000"
+
+    def test_minutes(self):
+        assert _format_srt_time(60.0) == "00:01:00,000"
+        assert _format_srt_time(65.333) == "00:01:05,333"
+
+    def test_hours(self):
+        assert _format_srt_time(3600.0) == "01:00:00,000"
+        assert _format_srt_time(3665.789) == "01:01:05,789"
+
+    def test_comma_decimal_separator(self):
+        """SRT uses comma instead of dot for decimal separator."""
+        result = _format_srt_time(1.5)
+        assert "," in result
+        assert "." not in result
+
+
+class TestFormatSubtitleTimeline:
+    """Tests for format_subtitle_timeline function."""
+
+    def test_empty_list(self):
+        assert format_subtitle_timeline([]) == ""
+
+    def test_none_list(self):
+        assert format_subtitle_timeline(None) == ""
+
+    def test_timeline_format_basic(self):
+        raw = [
+            {"content": "Hello", "from": 0.0, "to": 2.5},
+        ]
+        result = format_subtitle_timeline(raw, format="timeline")
+        assert "[00:00.000 --> 00:02.500] Hello" in result
+
+    def test_timeline_format_multiple(self):
+        raw = [
+            {"content": "First", "from": 0.0, "to": 2.0},
+            {"content": "Second", "from": 2.0, "to": 5.5},
+        ]
+        result = format_subtitle_timeline(raw, format="timeline")
+        lines = result.split("\n")
+        assert "[00:00.000 --> 00:02.000] First" in lines[0]
+        assert "[00:02.000 --> 00:05.500] Second" in lines[1]
+
+    def test_srt_format_basic(self):
+        raw = [
+            {"content": "Hello", "from": 0.0, "to": 2.5},
+        ]
+        result = format_subtitle_timeline(raw, format="srt")
+        assert "1" in result
+        assert "00:00:00,000 --> 00:00:02,500" in result
+        assert "Hello" in result
+
+    def test_srt_format_multiple(self):
+        raw = [
+            {"content": "First", "from": 0.0, "to": 2.0},
+            {"content": "Second", "from": 2.0, "to": 5.0},
+        ]
+        result = format_subtitle_timeline(raw, format="srt")
+        lines = result.split("\n")
+        # SRT format: index, time, content, empty line
+        assert "1" in lines[0]
+        assert "2" in lines[4]
+        assert "First" in lines[2]
+        assert "Second" in lines[6]
+
+    def test_srt_format_empty_lines(self):
+        """SRT format should have empty lines between entries."""
+        raw = [
+            {"content": "Test", "from": 0.0, "to": 1.0},
+        ]
+        result = format_subtitle_timeline(raw, format="srt")
+        # Should end with empty line
+        assert result.endswith("\n")
+
+    def test_default_format_is_timeline(self):
+        raw = [
+            {"content": "Test", "from": 0.0, "to": 1.0},
+        ]
+        result = format_subtitle_timeline(raw)  # No format specified
+        assert "[00:00.000 --> 00:01.000] Test" == result
+
+    def test_chinese_content(self):
+        raw = [
+            {"content": "你好世界", "from": 0.0, "to": 2.0},
+        ]
+        result = format_subtitle_timeline(raw, format="timeline")
+        assert "你好世界" in result
+
+    def test_missing_fields(self):
+        """Handle missing 'from' or 'to' fields gracefully."""
+        raw = [
+            {"content": "Test"},  # Missing from/to
+        ]
+        result = format_subtitle_timeline(raw, format="timeline")
+        assert "[00:00.000 --> 00:00.000] Test" == result
+
+    def test_long_duration(self):
+        """Test with very long duration (hours)."""
+        raw = [
+            {"content": "Long video", "from": 3661.5, "to": 3665.789},
+        ]
+        result = format_subtitle_timeline(raw, format="timeline")
+        assert "[61:01.500 --> 61:05.789] Long video" in result
+
+
+class TestSubtitleDataStructure:
+    """Tests to verify subtitle data structure handling."""
+
+    def test_typical_subtitle_item(self):
+        """Test with typical Bilibili subtitle item structure."""
+        raw = [
+            {
+                "content": "欢迎观看本视频",
+                "from": 0.0,
+                "to": 2.5,
+                "location": 2,
+                "content_type": "text",
+            },
+            {
+                "content": "今天我们来聊聊 Python",
+                "from": 2.5,
+                "to": 5.0,
+                "location": 2,
+                "content_type": "text",
+            },
+        ]
+        result = format_subtitle_timeline(raw, format="timeline")
+        assert "欢迎观看本视频" in result
+        assert "今天我们来聊聊 Python" in result
+        assert "[00:00.000 --> 00:02.500]" in result
+        assert "[00:02.500 --> 00:05.000]" in result

--- a/uv.lock
+++ b/uv.lock
@@ -278,7 +278,7 @@ wheels = [
 
 [[package]]
 name = "bilibili-cli"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## 新功能

- 新增 `--subtitle` 选项，显示纯文本字幕
- 新增 `--subtitle-timeline (-st)` 选项，显示带时间戳的字幕
- 新增 `--subtitle-format` 选项（支持 timeline 和 srt 格式）
- 添加 `format_subtitle_timeline()` 及相关辅助函数

## 优化

- 简化字幕显示逻辑，合并重复的 else 分支
- 使用统一的 `display_content` 变量减少代码重复

## 测试

- 添加 22 个字幕格式化函数测试（tests/test_subtitle.py）
- 总测试数：206 个（184 + 22）全部通过

## 文档

- 更新 README.md 和 SKILL.md 添加字幕功能说明

## 使用示例

```bash
# 查看纯文本字幕
bili video BV1xxx --subtitle

# 查看带时间线的字幕
bili video BV1xxx --subtitle-timeline
bili video BV1xxx -st

# 导出为 SRT 格式
bili video BV1xxx -st --subtitle-format srt
bili video BV1xxx -st --subtitle-format srt > subtitles.srt
```

## 输出格式

### Timeline 格式
```
[00:00.000 --> 00:02.500] 欢迎观看本视频
[00:02.500 --> 00:05.000] 今天我们来聊聊 Python
```

### SRT 格式
```
1
00:00:00,000 --> 00:00:02,500
欢迎观看本视频

2
00:00:02,500 --> 00:00:05,000
今天我们来聊聊 Python
```