### PR TITLE
fix: subtitle structured output format and remove redundant items field

### DIFF
--- a/bili_cli/commands/video.py
+++ b/bili_cli/commands/video.py
@@ -98,11 +98,17 @@ def video(
         else:
             warnings.append({"code": "related_unavailable", "message": "获取相关推荐失败"})
 
+    effective_format = subtitle_format if subtitle_timeline else "plain"
+    subtitle_formatted = ""
+    if subtitle_timeline and subtitle_items and effective_format != "plain":
+        subtitle_formatted = client.format_subtitle_timeline(subtitle_items, output_format=effective_format)
+
     structured_payload = payloads.normalize_video_command_payload(
         info,
         subtitle_text=subtitle_text,
         subtitle_items=subtitle_items,
-        subtitle_format=subtitle_format if subtitle_timeline else "plain",
+        subtitle_format=effective_format,
+        subtitle_formatted_text=subtitle_formatted,
         ai_summary=ai_summary,
         comments=comments_items,
         related=related_items,

--- a/bili_cli/payloads.py
+++ b/bili_cli/payloads.py
@@ -94,21 +94,6 @@ def normalize_video_summary(video: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def normalize_subtitle_items(raw: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
-    items: list[dict[str, Any]] = []
-    for item in raw or []:
-        if not isinstance(item, dict):
-            continue
-        items.append(
-            {
-                "from": float(item.get("from", 0.0) or 0.0),
-                "to": float(item.get("to", 0.0) or 0.0),
-                "content": item.get("content", ""),
-            }
-        )
-    return items
-
-
 def normalize_comment(item: dict[str, Any]) -> dict[str, Any]:
     member = item.get("member", {}) if isinstance(item.get("member"), dict) else {}
     content = item.get("content", {}) if isinstance(item.get("content"), dict) else {}
@@ -272,16 +257,17 @@ def normalize_video_command_payload(
     subtitle_text: str = "",
     subtitle_items: list[dict[str, Any]] | None = None,
     subtitle_format: str = "timeline",
+    subtitle_formatted_text: str = "",
     ai_summary: str = "",
     comments: list[dict[str, Any]] | None = None,
     related: list[dict[str, Any]] | None = None,
     warnings: list[dict[str, str]] | None = None,
 ) -> dict[str, Any]:
-    subtitle_payload = {
-        "available": bool(subtitle_text or subtitle_items),
+    display_text = subtitle_formatted_text if subtitle_formatted_text else subtitle_text
+    subtitle_payload: dict[str, Any] = {
+        "available": bool(display_text or subtitle_items),
         "format": subtitle_format,
-        "text": subtitle_text,
-        "items": normalize_subtitle_items(subtitle_items),
+        "text": display_text,
     }
     return {
         "video": normalize_video_summary(info),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,8 +31,10 @@ def test_status_not_logged_in(runner):
 
 def test_status_logged_in(runner, mock_user_info):
     mock_cred = MagicMock()
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.get_self_info", new_callable=AsyncMock, return_value=mock_user_info):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.get_self_info", new_callable=AsyncMock, return_value=mock_user_info),
+    ):
         result = runner.invoke(cli, ["status"])
         assert "TestUP" in result.output
         assert "✅" in result.output
@@ -41,8 +43,10 @@ def test_status_logged_in(runner, mock_user_info):
 def test_status_auto_yaml_when_stdout_is_not_tty(runner, mock_user_info, monkeypatch):
     monkeypatch.setenv("OUTPUT", "auto")
     mock_cred = MagicMock()
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.get_self_info", new_callable=AsyncMock, return_value=mock_user_info):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.get_self_info", new_callable=AsyncMock, return_value=mock_user_info),
+    ):
         result = runner.invoke(cli, ["status"])
         assert result.exit_code == 0
         data = _load_yaml(result.output)
@@ -91,9 +95,11 @@ def test_user_not_found_yaml_error(runner):
 
 def test_whoami_json(runner, mock_user_info, mock_relation_info):
     mock_cred = MagicMock()
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.get_self_info", new_callable=AsyncMock, return_value=mock_user_info), \
-         patch("bili_cli.client.get_user_relation_info", new_callable=AsyncMock, return_value=mock_relation_info):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.get_self_info", new_callable=AsyncMock, return_value=mock_user_info),
+        patch("bili_cli.client.get_user_relation_info", new_callable=AsyncMock, return_value=mock_relation_info),
+    ):
         result = runner.invoke(cli, ["whoami", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.output)
@@ -105,9 +111,11 @@ def test_whoami_json(runner, mock_user_info, mock_relation_info):
 
 def test_whoami_yaml(runner, mock_user_info, mock_relation_info):
     mock_cred = MagicMock()
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.get_self_info", new_callable=AsyncMock, return_value=mock_user_info), \
-         patch("bili_cli.client.get_user_relation_info", new_callable=AsyncMock, return_value=mock_relation_info):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.get_self_info", new_callable=AsyncMock, return_value=mock_user_info),
+        patch("bili_cli.client.get_user_relation_info", new_callable=AsyncMock, return_value=mock_relation_info),
+    ):
         result = runner.invoke(cli, ["whoami", "--yaml"])
         assert result.exit_code == 0
         data = _load_yaml(result.output)
@@ -121,9 +129,11 @@ def test_whoami_yaml(runner, mock_user_info, mock_relation_info):
 
 
 def test_video_json(runner, mock_video_info):
-    with patch("bili_cli.commands.common.get_credential", return_value=None), \
-         patch("bili_cli.client.extract_bvid", return_value="BV1test123"), \
-         patch("bili_cli.client.get_video_info", new_callable=AsyncMock, return_value=mock_video_info):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=None),
+        patch("bili_cli.client.extract_bvid", return_value="BV1test123"),
+        patch("bili_cli.client.get_video_info", new_callable=AsyncMock, return_value=mock_video_info),
+    ):
         result = runner.invoke(cli, ["video", "BV1test123", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.output)["data"]
@@ -133,9 +143,11 @@ def test_video_json(runner, mock_video_info):
 
 
 def test_video_yaml(runner, mock_video_info):
-    with patch("bili_cli.commands.common.get_credential", return_value=None), \
-         patch("bili_cli.client.extract_bvid", return_value="BV1test123"), \
-         patch("bili_cli.client.get_video_info", new_callable=AsyncMock, return_value=mock_video_info):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=None),
+        patch("bili_cli.client.extract_bvid", return_value="BV1test123"),
+        patch("bili_cli.client.get_video_info", new_callable=AsyncMock, return_value=mock_video_info),
+    ):
         result = runner.invoke(cli, ["video", "BV1test123", "--yaml"])
         assert result.exit_code == 0
         data = _load_yaml(result.output)["data"]
@@ -144,9 +156,11 @@ def test_video_yaml(runner, mock_video_info):
 
 
 def test_video_display(runner, mock_video_info):
-    with patch("bili_cli.commands.common.get_credential", return_value=None), \
-         patch("bili_cli.client.extract_bvid", return_value="BV1test123"), \
-         patch("bili_cli.client.get_video_info", new_callable=AsyncMock, return_value=mock_video_info):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=None),
+        patch("bili_cli.client.extract_bvid", return_value="BV1test123"),
+        patch("bili_cli.client.get_video_info", new_callable=AsyncMock, return_value=mock_video_info),
+    ):
         result = runner.invoke(cli, ["video", "BV1test123"])
         assert result.exit_code == 0
         assert "测试视频标题" in result.output
@@ -154,9 +168,11 @@ def test_video_display(runner, mock_video_info):
 
 
 def test_video_does_not_load_optional_credential_when_no_optional_section(runner, mock_video_info):
-    with patch("bili_cli.commands.common.get_credential", return_value=None) as mock_get_cred, \
-         patch("bili_cli.client.extract_bvid", return_value="BV1test123"), \
-         patch("bili_cli.client.get_video_info", new_callable=AsyncMock, return_value=mock_video_info) as mock_get_info:
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=None) as mock_get_cred,
+        patch("bili_cli.client.extract_bvid", return_value="BV1test123"),
+        patch("bili_cli.client.get_video_info", new_callable=AsyncMock, return_value=mock_video_info) as mock_get_info,
+    ):
         result = runner.invoke(cli, ["video", "BV1test123"])
         assert result.exit_code == 0
         mock_get_cred.assert_not_called()
@@ -164,20 +180,24 @@ def test_video_does_not_load_optional_credential_when_no_optional_section(runner
 
 
 def test_video_uses_optional_credential_mode_when_needed(runner, mock_video_info):
-    with patch("bili_cli.commands.common.get_credential", return_value=None) as mock_get_cred, \
-         patch("bili_cli.client.extract_bvid", return_value="BV1test123"), \
-         patch("bili_cli.client.get_video_info", new_callable=AsyncMock, return_value=mock_video_info), \
-         patch("bili_cli.client.get_video_subtitle", new_callable=AsyncMock, return_value=("sub", [])):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=None) as mock_get_cred,
+        patch("bili_cli.client.extract_bvid", return_value="BV1test123"),
+        patch("bili_cli.client.get_video_info", new_callable=AsyncMock, return_value=mock_video_info),
+        patch("bili_cli.client.get_video_subtitle", new_callable=AsyncMock, return_value=("sub", [])),
+    ):
         result = runner.invoke(cli, ["video", "BV1test123", "--subtitle"])
         assert result.exit_code == 0
         mock_get_cred.assert_called_once_with(mode="optional")
 
 
 def test_video_subtitle_timeline_uses_optional_credential_mode_when_needed(runner, mock_video_info):
-    with patch("bili_cli.commands.common.get_credential", return_value=None) as mock_get_cred, \
-         patch("bili_cli.client.extract_bvid", return_value="BV1test123"), \
-         patch("bili_cli.client.get_video_info", new_callable=AsyncMock, return_value=mock_video_info), \
-         patch("bili_cli.client.get_video_subtitle", new_callable=AsyncMock, return_value=("sub", [])):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=None) as mock_get_cred,
+        patch("bili_cli.client.extract_bvid", return_value="BV1test123"),
+        patch("bili_cli.client.get_video_info", new_callable=AsyncMock, return_value=mock_video_info),
+        patch("bili_cli.client.get_video_subtitle", new_callable=AsyncMock, return_value=("sub", [])),
+    ):
         result = runner.invoke(cli, ["video", "BV1test123", "--subtitle-timeline"])
         assert result.exit_code == 0
         mock_get_cred.assert_called_once_with(mode="optional")
@@ -185,10 +205,12 @@ def test_video_subtitle_timeline_uses_optional_credential_mode_when_needed(runne
 
 def test_video_subtitle_timeline_prints_timeline_output(runner, mock_video_info):
     raw = [{"content": "Hello", "from": 0.0, "to": 2.5}]
-    with patch("bili_cli.commands.common.get_credential", return_value=None), \
-         patch("bili_cli.client.extract_bvid", return_value="BV1test123"), \
-         patch("bili_cli.client.get_video_info", new_callable=AsyncMock, return_value=mock_video_info), \
-         patch("bili_cli.client.get_video_subtitle", new_callable=AsyncMock, return_value=("Hello", raw)):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=None),
+        patch("bili_cli.client.extract_bvid", return_value="BV1test123"),
+        patch("bili_cli.client.get_video_info", new_callable=AsyncMock, return_value=mock_video_info),
+        patch("bili_cli.client.get_video_subtitle", new_callable=AsyncMock, return_value=("Hello", raw)),
+    ):
         result = runner.invoke(cli, ["video", "BV1test123", "--subtitle-timeline"])
         assert result.exit_code == 0
         assert "[00:00.000 --> 00:02.500] Hello" in result.output
@@ -196,10 +218,12 @@ def test_video_subtitle_timeline_prints_timeline_output(runner, mock_video_info)
 
 def test_video_subtitle_timeline_supports_srt_output(runner, mock_video_info):
     raw = [{"content": "Hello", "from": 0.0, "to": 2.5}]
-    with patch("bili_cli.commands.common.get_credential", return_value=None), \
-         patch("bili_cli.client.extract_bvid", return_value="BV1test123"), \
-         patch("bili_cli.client.get_video_info", new_callable=AsyncMock, return_value=mock_video_info), \
-         patch("bili_cli.client.get_video_subtitle", new_callable=AsyncMock, return_value=("Hello", raw)):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=None),
+        patch("bili_cli.client.extract_bvid", return_value="BV1test123"),
+        patch("bili_cli.client.get_video_info", new_callable=AsyncMock, return_value=mock_video_info),
+        patch("bili_cli.client.get_video_subtitle", new_callable=AsyncMock, return_value=("Hello", raw)),
+    ):
         result = runner.invoke(cli, ["video", "BV1test123", "--subtitle-timeline", "--subtitle-format", "srt"])
         assert result.exit_code == 0
         assert "00:00:00,000 --> 00:00:02,500" in result.output
@@ -209,17 +233,19 @@ def test_video_structured_output_includes_requested_extras(runner, mock_video_in
     raw = [{"content": "Hello", "from": 0.0, "to": 2.5}]
     comments = [{"rpid": 1, "member": {"mid": 2, "uname": "TestUser"}, "content": {"message": "Nice!"}, "like": 3}]
     related = [{"bvid": "BV1rel", "title": "Related Video", "owner": {"name": "UP"}}]
-    with patch("bili_cli.commands.common.get_credential", return_value=None), \
-         patch("bili_cli.client.extract_bvid", return_value="BV1test123"), \
-         patch("bili_cli.client.get_video_info", new_callable=AsyncMock, return_value=mock_video_info), \
-         patch("bili_cli.client.get_video_subtitle", new_callable=AsyncMock, return_value=("Hello", raw)), \
-         patch(
-             "bili_cli.client.get_video_ai_conclusion",
-             new_callable=AsyncMock,
-             return_value={"model_result": {"summary": "AI summary"}},
-         ), \
-         patch("bili_cli.client.get_video_comments", new_callable=AsyncMock, return_value={"replies": comments}), \
-         patch("bili_cli.client.get_related_videos", new_callable=AsyncMock, return_value=related):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=None),
+        patch("bili_cli.client.extract_bvid", return_value="BV1test123"),
+        patch("bili_cli.client.get_video_info", new_callable=AsyncMock, return_value=mock_video_info),
+        patch("bili_cli.client.get_video_subtitle", new_callable=AsyncMock, return_value=("Hello", raw)),
+        patch(
+            "bili_cli.client.get_video_ai_conclusion",
+            new_callable=AsyncMock,
+            return_value={"model_result": {"summary": "AI summary"}},
+        ),
+        patch("bili_cli.client.get_video_comments", new_callable=AsyncMock, return_value={"replies": comments}),
+        patch("bili_cli.client.get_related_videos", new_callable=AsyncMock, return_value=related),
+    ):
         result = runner.invoke(
             cli,
             ["video", "BV1test123", "--subtitle-timeline", "--ai", "--comments", "--related", "--json"],
@@ -228,17 +254,21 @@ def test_video_structured_output_includes_requested_extras(runner, mock_video_in
         data = json.loads(result.output)["data"]
         assert data["video"]["bvid"] == "BV1test123"
         assert data["subtitle"]["available"] is True
-        assert data["subtitle"]["items"][0]["content"] == "Hello"
+        assert data["subtitle"]["format"] == "timeline"
+        assert "[00:00.000 --> 00:02.500] Hello" in data["subtitle"]["text"]
+        assert "items" not in data["subtitle"]
         assert data["ai_summary"] == "AI summary"
         assert data["comments"][0]["author"]["name"] == "TestUser"
         assert data["related"][0]["bvid"] == "BV1rel"
 
 
 def test_video_subtitle_error_is_nonfatal(runner, mock_video_info):
-    with patch("bili_cli.commands.common.get_credential", return_value=None), \
-         patch("bili_cli.client.extract_bvid", return_value="BV1test123"), \
-         patch("bili_cli.client.get_video_info", new_callable=AsyncMock, return_value=mock_video_info), \
-         patch("bili_cli.client.get_video_subtitle", new_callable=AsyncMock, side_effect=Exception("boom")):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=None),
+        patch("bili_cli.client.extract_bvid", return_value="BV1test123"),
+        patch("bili_cli.client.get_video_info", new_callable=AsyncMock, return_value=mock_video_info),
+        patch("bili_cli.client.get_video_subtitle", new_callable=AsyncMock, side_effect=Exception("boom")),
+    ):
         result = runner.invoke(cli, ["video", "BV1test123", "--subtitle"])
         assert result.exit_code == 0
         assert "获取字幕失败" in result.output
@@ -251,9 +281,11 @@ def test_video_invalid_bvid(runner):
 
 
 def test_video_api_error_returns_nonzero(runner):
-    with patch("bili_cli.commands.common.get_credential", return_value=None), \
-         patch("bili_cli.client.extract_bvid", return_value="BV1test123"), \
-         patch("bili_cli.client.get_video_info", new_callable=AsyncMock, side_effect=Exception("api down")):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=None),
+        patch("bili_cli.client.extract_bvid", return_value="BV1test123"),
+        patch("bili_cli.client.get_video_info", new_callable=AsyncMock, side_effect=Exception("api down")),
+    ):
         result = runner.invoke(cli, ["video", "BV1test123"])
         assert result.exit_code != 0
         assert "获取视频信息失败" in result.output
@@ -273,8 +305,10 @@ def test_hot_command(runner):
             }
         ]
     }
-    with patch("bili_cli.commands.common.get_credential", return_value=None), \
-         patch("bili_cli.client.get_hot_videos", new_callable=AsyncMock, return_value=mock_data):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=None),
+        patch("bili_cli.client.get_hot_videos", new_callable=AsyncMock, return_value=mock_data),
+    ):
         result = runner.invoke(cli, ["hot", "--max", "1"])
         assert result.exit_code == 0
         assert "BV1hot" in result.output
@@ -291,8 +325,10 @@ def test_hot_forwards_page_option(runner):
 
 def test_hot_json(runner):
     mock_data = {"list": [{"bvid": "BV1hot", "title": "Hot"}]}
-    with patch("bili_cli.commands.common.get_credential", return_value=None), \
-         patch("bili_cli.client.get_hot_videos", new_callable=AsyncMock, return_value=mock_data):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=None),
+        patch("bili_cli.client.get_hot_videos", new_callable=AsyncMock, return_value=mock_data),
+    ):
         result = runner.invoke(cli, ["hot", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.output)["data"]
@@ -301,8 +337,10 @@ def test_hot_json(runner):
 
 def test_hot_yaml(runner):
     mock_data = {"list": [{"bvid": "BV1hot", "title": "Hot"}]}
-    with patch("bili_cli.commands.common.get_credential", return_value=None), \
-         patch("bili_cli.client.get_hot_videos", new_callable=AsyncMock, return_value=mock_data):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=None),
+        patch("bili_cli.client.get_hot_videos", new_callable=AsyncMock, return_value=mock_data),
+    ):
         result = runner.invoke(cli, ["hot", "--yaml"])
         assert result.exit_code == 0
         data = _load_yaml(result.output)["data"]
@@ -336,9 +374,11 @@ def test_rank_json(runner):
 
 
 def test_structured_output_flags_are_mutually_exclusive(runner, mock_video_info):
-    with patch("bili_cli.commands.common.get_credential", return_value=None), \
-         patch("bili_cli.client.extract_bvid", return_value="BV1test123"), \
-         patch("bili_cli.client.get_video_info", new_callable=AsyncMock, return_value=mock_video_info):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=None),
+        patch("bili_cli.client.extract_bvid", return_value="BV1test123"),
+        patch("bili_cli.client.get_video_info", new_callable=AsyncMock, return_value=mock_video_info),
+    ):
         result = runner.invoke(cli, ["video", "BV1test123", "--json", "--yaml"])
         assert result.exit_code != 0
         assert "不能同时使用 --json 和 --yaml" in result.output
@@ -369,8 +409,10 @@ def test_rank_invalid_max(runner):
 
 def test_search_user(runner):
     mock_results = [{"mid": 123, "uname": "TestUser", "fans": 1000, "videos": 10, "usign": "Hi"}]
-    with patch("bili_cli.commands.common.get_credential", return_value=None), \
-         patch("bili_cli.client.search_user", new_callable=AsyncMock, return_value=mock_results):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=None),
+        patch("bili_cli.client.search_user", new_callable=AsyncMock, return_value=mock_results),
+    ):
         result = runner.invoke(cli, ["search", "test"])
         assert result.exit_code == 0
         assert "TestUser" in result.output
@@ -378,8 +420,10 @@ def test_search_user(runner):
 
 def test_search_video(runner):
     mock_results = [{"bvid": "BV1found", "title": "Found Video", "author": "UP", "play": 5000, "duration": "10:30"}]
-    with patch("bili_cli.commands.common.get_credential", return_value=None), \
-         patch("bili_cli.client.search_video", new_callable=AsyncMock, return_value=mock_results):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=None),
+        patch("bili_cli.client.search_video", new_callable=AsyncMock, return_value=mock_results),
+    ):
         result = runner.invoke(cli, ["search", "test", "--type", "video"])
         assert result.exit_code == 0
         assert "BV1found" in result.output
@@ -422,8 +466,10 @@ def test_search_invalid_max(runner):
 
 
 def test_search_empty(runner):
-    with patch("bili_cli.commands.common.get_credential", return_value=None), \
-         patch("bili_cli.client.search_user", new_callable=AsyncMock, return_value=[]):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=None),
+        patch("bili_cli.client.search_user", new_callable=AsyncMock, return_value=[]),
+    ):
         result = runner.invoke(cli, ["search", "nonexistent_xyz"])
         assert "未找到" in result.output
 
@@ -446,9 +492,11 @@ def test_search_video_api_error_returns_nonzero(runner):
 
 
 def test_user_by_uid(runner, mock_user_info, mock_relation_info):
-    with patch("bili_cli.commands.common.get_credential", return_value=None), \
-         patch("bili_cli.client.get_user_info", new_callable=AsyncMock, return_value=mock_user_info), \
-         patch("bili_cli.client.get_user_relation_info", new_callable=AsyncMock, return_value=mock_relation_info):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=None),
+        patch("bili_cli.client.get_user_info", new_callable=AsyncMock, return_value=mock_user_info),
+        patch("bili_cli.client.get_user_relation_info", new_callable=AsyncMock, return_value=mock_relation_info),
+    ):
         result = runner.invoke(cli, ["user", "946974"])
         assert result.exit_code == 0
         assert "TestUP" in result.output
@@ -457,8 +505,10 @@ def test_user_by_uid(runner, mock_user_info, mock_relation_info):
 
 def test_user_videos_json(runner):
     videos = [{"bvid": "BV1new", "title": "New Video", "play": 123, "length": "01:23"}]
-    with patch("bili_cli.commands.common.get_credential", return_value=None), \
-         patch("bili_cli.client.get_user_videos", new_callable=AsyncMock, return_value=videos):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=None),
+        patch("bili_cli.client.get_user_videos", new_callable=AsyncMock, return_value=videos),
+    ):
         result = runner.invoke(cli, ["user-videos", "946974", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.output)["data"]
@@ -471,8 +521,10 @@ def test_user_videos_invalid_max(runner):
 
 
 def test_user_videos_api_error_returns_nonzero(runner):
-    with patch("bili_cli.commands.common.get_credential", return_value=None), \
-         patch("bili_cli.client.get_user_videos", new_callable=AsyncMock, side_effect=Exception("api down")):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=None),
+        patch("bili_cli.client.get_user_videos", new_callable=AsyncMock, side_effect=Exception("api down")),
+    ):
         result = runner.invoke(cli, ["user-videos", "946974"])
         assert result.exit_code != 0
         assert "获取视频列表失败" in result.output
@@ -499,8 +551,10 @@ def test_user_by_name_with_missing_uid_returns_nonzero(runner):
 def test_favorites_list_success(runner):
     mock_cred = MagicMock()
     favs = [{"id": 100, "title": "默认收藏夹", "media_count": 8}]
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.get_favorite_list", new_callable=AsyncMock, return_value=favs):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.get_favorite_list", new_callable=AsyncMock, return_value=favs),
+    ):
         result = runner.invoke(cli, ["favorites"])
         assert result.exit_code == 0
         assert "默认收藏夹" in result.output
@@ -513,8 +567,10 @@ def test_favorites_detail_success(runner):
         "medias": [{"bvid": "BV1fav", "title": "Fav Video", "upper": {"name": "FavUP"}, "duration": 120}],
         "has_more": True,
     }
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.get_favorite_videos", new_callable=AsyncMock, return_value=data):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.get_favorite_videos", new_callable=AsyncMock, return_value=data),
+    ):
         result = runner.invoke(cli, ["favorites", "100", "--page", "2"])
         assert result.exit_code == 0
         assert "BV1fav" in result.output
@@ -535,8 +591,10 @@ def test_favorites_invalid_page(runner):
 
 def test_favorites_api_error_returns_nonzero(runner):
     mock_cred = MagicMock()
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.get_favorite_list", new_callable=AsyncMock, side_effect=Exception("api down")):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.get_favorite_list", new_callable=AsyncMock, side_effect=Exception("api down")),
+    ):
         result = runner.invoke(cli, ["favorites"])
         assert result.exit_code != 0
         assert "获取收藏夹列表失败" in result.output
@@ -551,13 +609,15 @@ def test_following_requires_login(runner):
 
 def test_following_success(runner):
     mock_cred = MagicMock()
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.get_self_info", new_callable=AsyncMock, return_value={"mid": 946974}), \
-         patch(
-             "bili_cli.client.get_followings",
-             new_callable=AsyncMock,
-             return_value={"list": [{"mid": 1, "uname": "UPA", "sign": "hello"}], "total": 1},
-         ):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.get_self_info", new_callable=AsyncMock, return_value={"mid": 946974}),
+        patch(
+            "bili_cli.client.get_followings",
+            new_callable=AsyncMock,
+            return_value={"list": [{"mid": 1, "uname": "UPA", "sign": "hello"}], "total": 1},
+        ),
+    ):
         result = runner.invoke(cli, ["following"])
         assert result.exit_code == 0
         assert "UPA" in result.output
@@ -571,8 +631,10 @@ def test_following_invalid_page(runner):
 
 def test_following_api_error_returns_nonzero(runner):
     mock_cred = MagicMock()
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.get_self_info", new_callable=AsyncMock, side_effect=Exception("api down")):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.get_self_info", new_callable=AsyncMock, side_effect=Exception("api down")),
+    ):
         result = runner.invoke(cli, ["following"])
         assert result.exit_code != 0
         assert "获取关注列表失败" in result.output
@@ -587,8 +649,10 @@ def test_history_requires_login(runner):
 
 def test_history_api_error_returns_nonzero(runner):
     mock_cred = MagicMock()
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.get_watch_history", new_callable=AsyncMock, side_effect=Exception("api down")):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.get_watch_history", new_callable=AsyncMock, side_effect=Exception("api down")),
+    ):
         result = runner.invoke(cli, ["history"])
         assert result.exit_code != 0
         assert "获取观看历史失败" in result.output
@@ -596,8 +660,10 @@ def test_history_api_error_returns_nonzero(runner):
 
 def test_history_forwards_page_and_max(runner):
     mock_cred = MagicMock()
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.get_watch_history", new_callable=AsyncMock, return_value={"list": []}) as mock_history:
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.get_watch_history", new_callable=AsyncMock, return_value={"list": []}) as mock_history,
+    ):
         result = runner.invoke(cli, ["history", "--page", "2", "--max", "40"])
         assert result.exit_code == 0
         mock_history.assert_awaited_once_with(page=2, count=40, credential=mock_cred)
@@ -623,8 +689,10 @@ def test_watch_later_requires_login(runner):
 def test_watch_later_success(runner):
     mock_cred = MagicMock()
     data = {"list": [{"bvid": "BV1later", "title": "Later", "owner": {"name": "UP"}, "duration": 60}], "count": 1}
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.get_toview", new_callable=AsyncMock, return_value=data):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.get_toview", new_callable=AsyncMock, return_value=data),
+    ):
         result = runner.invoke(cli, ["watch-later"])
         assert result.exit_code == 0
         assert "BV1later" in result.output
@@ -632,8 +700,10 @@ def test_watch_later_success(runner):
 
 def test_watch_later_api_error_returns_nonzero(runner):
     mock_cred = MagicMock()
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.get_toview", new_callable=AsyncMock, side_effect=Exception("api down")):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.get_toview", new_callable=AsyncMock, side_effect=Exception("api down")),
+    ):
         result = runner.invoke(cli, ["watch-later"])
         assert result.exit_code != 0
         assert "获取稍后再看失败" in result.output
@@ -660,8 +730,10 @@ def test_feed_success(runner):
         ],
         "next_offset": 12345,
     }
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.get_dynamic_feed", new_callable=AsyncMock, return_value=feed_data):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.get_dynamic_feed", new_callable=AsyncMock, return_value=feed_data),
+    ):
         result = runner.invoke(cli, ["feed"])
         assert result.exit_code == 0
         assert "UPA" in result.output
@@ -671,8 +743,10 @@ def test_feed_success(runner):
 
 def test_feed_api_error_returns_nonzero(runner):
     mock_cred = MagicMock()
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.get_dynamic_feed", new_callable=AsyncMock, side_effect=Exception("api down")):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.get_dynamic_feed", new_callable=AsyncMock, side_effect=Exception("api down")),
+    ):
         result = runner.invoke(cli, ["feed"])
         assert result.exit_code != 0
         assert "获取动态失败" in result.output
@@ -680,8 +754,10 @@ def test_feed_api_error_returns_nonzero(runner):
 
 def test_feed_forwards_offset(runner):
     mock_cred = MagicMock()
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.get_dynamic_feed", new_callable=AsyncMock, return_value={"items": []}) as mock_feed:
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.get_dynamic_feed", new_callable=AsyncMock, return_value={"items": []}) as mock_feed,
+    ):
         result = runner.invoke(cli, ["feed", "--offset", "123"])
         assert result.exit_code == 0
         mock_feed.assert_awaited_once_with(offset="123", credential=mock_cred)
@@ -698,9 +774,11 @@ def test_my_dynamics_success(runner):
         ],
         "next_offset": 456,
     }
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.get_self_info", new_callable=AsyncMock, return_value={"mid": 946974}), \
-         patch("bili_cli.client.get_user_dynamics", new_callable=AsyncMock, return_value=data):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.get_self_info", new_callable=AsyncMock, return_value={"mid": 946974}),
+        patch("bili_cli.client.get_user_dynamics", new_callable=AsyncMock, return_value=data),
+    ):
         result = runner.invoke(cli, ["my-dynamics", "--max", "1"])
         assert result.exit_code == 0
         assert "123" in result.output
@@ -710,9 +788,11 @@ def test_my_dynamics_success(runner):
 
 def test_my_dynamics_forwards_options(runner):
     mock_cred = MagicMock()
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.get_self_info", new_callable=AsyncMock, return_value={"mid": 946974}), \
-         patch("bili_cli.client.get_user_dynamics", new_callable=AsyncMock, return_value={"cards": []}) as mock_get:
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.get_self_info", new_callable=AsyncMock, return_value={"mid": 946974}),
+        patch("bili_cli.client.get_user_dynamics", new_callable=AsyncMock, return_value={"cards": []}) as mock_get,
+    ):
         result = runner.invoke(cli, ["my-dynamics", "--offset", "99", "--top"])
         assert result.exit_code == 0
         mock_get.assert_awaited_once_with(uid=946974, offset=99, need_top=True, credential=mock_cred)
@@ -720,8 +800,10 @@ def test_my_dynamics_forwards_options(runner):
 
 def test_dynamic_post_text_success(runner):
     mock_cred = MagicMock()
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.post_text_dynamic", new_callable=AsyncMock, return_value={"dynamic_id": 1001}) as mock_post:
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.post_text_dynamic", new_callable=AsyncMock, return_value={"dynamic_id": 1001}) as mock_post,
+    ):
         result = runner.invoke(cli, ["dynamic-post", "hello dynamic"])
         assert result.exit_code == 0
         assert "1001" in result.output
@@ -733,8 +815,10 @@ def test_dynamic_post_from_file_success(runner):
     with runner.isolated_filesystem():
         with open("dyn.txt", "w", encoding="utf-8") as f:
             f.write("from file dynamic")
-        with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-             patch("bili_cli.client.post_text_dynamic", new_callable=AsyncMock, return_value={}) as mock_post:
+        with (
+            patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+            patch("bili_cli.client.post_text_dynamic", new_callable=AsyncMock, return_value={}) as mock_post,
+        ):
             result = runner.invoke(cli, ["dynamic-post", "--from-file", "dyn.txt"])
             assert result.exit_code == 0
             mock_post.assert_awaited_once_with("from file dynamic", credential=mock_cred)
@@ -742,8 +826,10 @@ def test_dynamic_post_from_file_success(runner):
 
 def test_dynamic_delete_yes_calls_client(runner):
     mock_cred = MagicMock()
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.delete_dynamic", new_callable=AsyncMock, return_value={}) as mock_delete:
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.delete_dynamic", new_callable=AsyncMock, return_value={}) as mock_delete,
+    ):
         result = runner.invoke(cli, ["dynamic-delete", "123", "--yes"])
         assert result.exit_code == 0
         mock_delete.assert_awaited_once_with(dynamic_id=123, credential=mock_cred)
@@ -776,8 +862,10 @@ def test_triple_requires_login(runner):
 def test_unfollow_yes_calls_client(runner):
     mock_cred = MagicMock()
     mock_cred.bili_jct = "valid_jct"
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.unfollow_user", new_callable=AsyncMock, return_value={}) as mock_unfollow:
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.unfollow_user", new_callable=AsyncMock, return_value={}) as mock_unfollow,
+    ):
         result = runner.invoke(cli, ["unfollow", "946974", "--yes"])
         assert result.exit_code == 0
         mock_unfollow.assert_awaited_once_with(uid=946974, credential=mock_cred)
@@ -786,9 +874,11 @@ def test_unfollow_yes_calls_client(runner):
 def test_like_json_output(runner):
     mock_cred = MagicMock()
     mock_cred.bili_jct = "valid_jct"
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.extract_bvid", return_value="BV1ok"), \
-         patch("bili_cli.client.like_video", new_callable=AsyncMock, return_value={}):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.extract_bvid", return_value="BV1ok"),
+        patch("bili_cli.client.like_video", new_callable=AsyncMock, return_value={}),
+    ):
         result = runner.invoke(cli, ["like", "BV1ok", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.output)["data"]
@@ -799,9 +889,11 @@ def test_like_json_output(runner):
 def test_coin_yaml_output(runner):
     mock_cred = MagicMock()
     mock_cred.bili_jct = "valid_jct"
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.extract_bvid", return_value="BV1ok"), \
-         patch("bili_cli.client.coin_video", new_callable=AsyncMock, return_value={}):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.extract_bvid", return_value="BV1ok"),
+        patch("bili_cli.client.coin_video", new_callable=AsyncMock, return_value={}),
+    ):
         result = runner.invoke(cli, ["coin", "BV1ok", "--num", "2", "--yaml"])
         assert result.exit_code == 0
         data = _load_yaml(result.output)["data"]
@@ -812,9 +904,11 @@ def test_coin_yaml_output(runner):
 def test_triple_json_output(runner):
     mock_cred = MagicMock()
     mock_cred.bili_jct = "valid_jct"
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.extract_bvid", return_value="BV1ok"), \
-         patch("bili_cli.client.triple_video", new_callable=AsyncMock, return_value={"like": True, "coin": True, "fav": True}):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.extract_bvid", return_value="BV1ok"),
+        patch("bili_cli.client.triple_video", new_callable=AsyncMock, return_value={"like": True, "coin": True, "fav": True}),
+    ):
         result = runner.invoke(cli, ["triple", "BV1ok", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.output)["data"]
@@ -844,8 +938,10 @@ def test_like_requires_write_credential(runner):
 def test_interaction_invalid_bvid_returns_nonzero(runner, cmd):
     mock_cred = MagicMock()
     mock_cred.bili_jct = "valid_jct"
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.extract_bvid", side_effect=ValueError("bad bvid")):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.extract_bvid", side_effect=ValueError("bad bvid")),
+    ):
         result = runner.invoke(cli, [cmd, "invalid"])
         assert result.exit_code != 0
         assert "bad bvid" in result.output
@@ -854,9 +950,11 @@ def test_interaction_invalid_bvid_returns_nonzero(runner, cmd):
 def test_like_failure_returns_nonzero(runner):
     mock_cred = MagicMock()
     mock_cred.bili_jct = "valid_jct"
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.extract_bvid", return_value="BV1ok"), \
-         patch("bili_cli.client.like_video", new_callable=AsyncMock, side_effect=Exception("boom")):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.extract_bvid", return_value="BV1ok"),
+        patch("bili_cli.client.like_video", new_callable=AsyncMock, side_effect=Exception("boom")),
+    ):
         result = runner.invoke(cli, ["like", "BV1ok"])
         assert result.exit_code != 0
         assert "操作失败" in result.output
@@ -865,9 +963,11 @@ def test_like_failure_returns_nonzero(runner):
 def test_coin_failure_returns_nonzero(runner):
     mock_cred = MagicMock()
     mock_cred.bili_jct = "valid_jct"
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.extract_bvid", return_value="BV1ok"), \
-         patch("bili_cli.client.coin_video", new_callable=AsyncMock, side_effect=Exception("boom")):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.extract_bvid", return_value="BV1ok"),
+        patch("bili_cli.client.coin_video", new_callable=AsyncMock, side_effect=Exception("boom")),
+    ):
         result = runner.invoke(cli, ["coin", "BV1ok"])
         assert result.exit_code != 0
         assert "投币失败" in result.output
@@ -876,9 +976,11 @@ def test_coin_failure_returns_nonzero(runner):
 def test_triple_failure_returns_nonzero(runner):
     mock_cred = MagicMock()
     mock_cred.bili_jct = "valid_jct"
-    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
-         patch("bili_cli.client.extract_bvid", return_value="BV1ok"), \
-         patch("bili_cli.client.triple_video", new_callable=AsyncMock, side_effect=Exception("boom")):
+    with (
+        patch("bili_cli.commands.common.get_credential", return_value=mock_cred),
+        patch("bili_cli.client.extract_bvid", return_value="BV1ok"),
+        patch("bili_cli.client.triple_video", new_callable=AsyncMock, side_effect=Exception("boom")),
+    ):
         result = runner.invoke(cli, ["triple", "BV1ok"])
         assert result.exit_code != 0
         assert "三连失败" in result.output


### PR DESCRIPTION
## Summary
- Fix `--subtitle-format srt` not producing actual SRT formatted text in structured output (`--json`/`--yaml`)
- Remove redundant `items` field from subtitle payload — keep only `text` for AI/human consumers
- Clean up unused `normalize_subtitle_items` function

## Changes
- `bili_cli/commands/video.py`: Compute formatted text based on `subtitle_format` and pass to payload
- `bili_cli/payloads.py`: 
  - Add `subtitle_formatted_text` parameter to `normalize_video_command_payload`
  - Use formatted text when available, fallback to plain text
  - Remove `items` field from subtitle payload
  - Remove unused `normalize_subtitle_items` function
- `tests/test_cli.py`: Update test to verify timeline format text instead of items

## Before
```json
{
  "subtitle": {
    "available": true,
    "format": "srt",
    "text": "plain text...",  // ❌ not SRT format
    "items": [...]            // redundant
  }
}
```

## After
```json
{
  "subtitle": {
    "available": true,
    "format": "srt",
    "text": "1\n00:00:00,121 --> 00:00:05,121\n永不放弃你...\n\n2\n..."  // ✅ actual SRT
  }
}
```