### PR TITLE
fix: preserve write-capable auth credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ bilibili-cli uses a 3-tier authentication strategy:
 2. **Browser cookies** — auto-extracts from Chrome, Firefox, Edge, or Brave
 3. **QR code login** — `bili login` displays a QR code in the terminal
 
-Credentials are validated on use for authenticated commands. Expired cookies are automatically cleared, while transient network validation failures keep local credentials for best-effort fallback.
-`bili status` exits with code `0` only when authenticated; otherwise it exits with `1`.
+Credentials are validated on use for authenticated commands. Expired cookies are automatically cleared, while transient network validation failures keep local credentials for read-only best-effort fallback. Write commands fail closed until validation succeeds and a `bili_jct` is present. A stale browser refresh never replaces a saved write-capable credential with a read-only one, and QR login only reports success after receiving a write-capable credential.
+`bili status` exits with code `0` when authenticated and reports whether the credential is write-capable; otherwise it exits with `1`.
 
 Most commands work without login. Subtitles, favorites/following/watch-later/history, feed, my-dynamics, and interactions require authentication. Write actions (like/coin/triple/unfollow/dynamic-post/dynamic-delete) require write-capable credential (`bili_jct`).
 
@@ -372,7 +372,9 @@ bilibili-cli 采用三级认证策略：
 2. **浏览器 Cookie** — 自动从 Chrome、Firefox、Edge、Brave 提取
 3. **扫码登录** — `bili login` 在终端显示二维码
 
-需要认证的命令会自动校验凭证。过期 Cookie 会自动清除；如果只是临时网络异常，不会误清本地凭证（会以 best-effort 继续尝试）。
+需要认证的命令会自动校验凭证。过期 Cookie 会自动清除；如果只是临时网络异常，读操作会保留本地凭证以 best-effort 尝试，写操作则会在验证成功且包含 `bili_jct` 前 fail closed。过期凭证从浏览器刷新时，不会用只读凭证覆盖已有的可写凭证；扫码登录只有拿到可写凭证才会报告成功。
+
+`bili status` 在已登录时会标明凭证是否支持写操作；未登录时退出码为 `1`。
 
 大部分命令无需登录。字幕、收藏夹、动态和互动操作需要登录。写操作（like/coin/triple/unfollow/dynamic-post/dynamic-delete）需要可写凭证（包含 `bili_jct`）。
 

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -26,7 +26,7 @@ error:
 - non-TTY stdout defaults to YAML
 - command payloads are normalized at the CLI layer
 - list-like results are typically returned under `data.items`
-- `status` returns `data.authenticated` plus `data.user`
+- `status` returns `data.authenticated`, `data.write_capable`, and `data.user`
 - `whoami` returns `data.user` and `data.relation`
 - `video` returns `data.video`, `data.subtitle`, `data.ai_summary`, `data.comments`, `data.related`, and `data.warnings`
 - write commands return normalized action payloads with `data.success` and `data.action`

--- a/bili_cli/auth.py
+++ b/bili_cli/auth.py
@@ -54,15 +54,28 @@ def get_credential(mode: AuthMode = "read") -> Credential | None:
     # 1. Saved credential file
     cred = _load_saved_credential()
     if cred:
+        # Optional credentials are intentionally local-only.  In particular,
+        # do not let a stale-file refresh replace the credential used by a
+        # later write operation.
+        if mode == "optional":
+            return cred
+
+        saved_supports_write = _has_write_capability(cred)
         # Check TTL — try to refresh from browser if stale
         if _is_credential_stale():
             logger.info("Credential older than %d days, attempting browser refresh", CREDENTIAL_TTL_DAYS)
-            fresh = _extract_browser_credential()
+            fresh = _extract_browser_credential(require_write=require_write)
             if fresh:
                 validation = _validate_credential(fresh, require_write=require_write)
                 if validation is True:
                     logger.info("Refreshed credential from browser")
-                    save_credential(fresh)
+                    # A read-only browser extraction must not clobber a
+                    # previously saved write-capable credential when status or
+                    # another read command triggers the refresh.
+                    if saved_supports_write and not _has_write_capability(fresh):
+                        logger.warning("Browser refresh returned a read-only credential; keeping saved write capability")
+                    else:
+                        save_credential(fresh)
                     return fresh
             # Refresh failed — validate existing credential
             logger.warning(
@@ -70,24 +83,28 @@ def get_credential(mode: AuthMode = "read") -> Credential | None:
                 CREDENTIAL_TTL_DAYS,
             )
 
-        if mode == "optional":
-            return cred
         validation = _validate_credential(cred, require_write=require_write)
         if validation is True:
             logger.info("Loaded valid credential from %s", CREDENTIAL_FILE)
             return cred
         if validation is None:
+            if require_write:
+                logger.warning("Credential validation is unavailable; refusing to use it for a write operation")
+                return None
             logger.warning("Credential validation failed due to network; using saved credential as best effort")
             return cred
         if validation is False:
-            logger.warning("Saved credential is expired, clearing")
-            clear_credential()
+            if require_write and bool(cred.sessdata) and not bool(cred.bili_jct):
+                logger.warning("Saved credential is read-only; keeping it for read operations")
+            else:
+                logger.warning("Saved credential is expired, clearing")
+                clear_credential()
 
     if mode == "optional":
         return None
 
     # 2. Browser cookie extraction
-    cred = _extract_browser_credential()
+    cred = _extract_browser_credential(require_write=require_write)
     if cred:
         validation = _validate_credential(cred, require_write=require_write)
         if validation is True:
@@ -95,12 +112,20 @@ def get_credential(mode: AuthMode = "read") -> Credential | None:
             save_credential(cred)
             return cred
         if validation is None:
+            if require_write:
+                logger.warning("Browser credential validation is unavailable; refusing to use it for a write operation")
+                return None
             logger.warning("Skipping browser credential validation due to network; using best effort")
             return cred
         if validation is False:
             logger.warning("Browser cookies are expired/invalid")
 
     return None
+
+
+def _has_write_capability(credential: Credential) -> bool:
+    """Return whether a credential has the fields required by write APIs."""
+    return bool(getattr(credential, "sessdata", "")) and bool(getattr(credential, "bili_jct", ""))
 
 
 def _is_credential_stale() -> bool:
@@ -172,18 +197,22 @@ def _load_saved_credential() -> Credential | None:
         return None
 
 
-def _extract_browser_credential() -> Credential | None:
+def _extract_browser_credential(require_write: bool = False) -> Credential | None:
     """Extract Bilibili cookies from local browsers using browser-cookie3.
 
     Runs extraction in a subprocess with timeout to avoid hanging
     when the browser is running (Chrome DB lock issue).
     """
-    extract_script = '''
+    cookie_check = 'if cookies.get("SESSDATA"):'
+    if require_write:
+        cookie_check = 'if cookies.get("SESSDATA") and cookies.get("bili_jct"):'
+
+    extract_script = f'''
 import json, sys
 try:
     import browser_cookie3 as bc3
 except ImportError:
-    print(json.dumps({"error": "not_installed"}))
+    print(json.dumps({{"error": "not_installed"}}))
     sys.exit(0)
 
 browsers = [
@@ -196,14 +225,14 @@ browsers = [
 for name, loader in browsers:
     try:
         cj = loader(domain_name=".bilibili.com")
-        cookies = {c.name: c.value for c in cj if "bilibili.com" in (c.domain or "")}
-        if "SESSDATA" in cookies:
-            print(json.dumps({"browser": name, "cookies": cookies}))
+        cookies = {{c.name: c.value for c in cj if "bilibili.com" in (c.domain or "")}}
+        {cookie_check}
+            print(json.dumps({{"browser": name, "cookies": cookies}}))
             sys.exit(0)
     except Exception:
         pass
 
-print(json.dumps({"error": "no_cookies"}))
+print(json.dumps({{"error": "no_cookies"}}))
 '''
 
     try:
@@ -395,6 +424,8 @@ async def qr_login() -> Credential:
 
         if state == QrCodeLoginEvents.DONE:
             credential = login.get_credential()
+            if not _has_write_capability(credential):
+                raise RuntimeError("二维码登录未获得可写凭证，请重试")
             save_credential(credential)
             print("\n✅ 登录成功！凭证已保存")
             return credential

--- a/bili_cli/commands/account.py
+++ b/bili_cli/commands/account.py
@@ -55,13 +55,19 @@ def status(as_json: bool, as_yaml: bool):
     payload = common.success_payload(
         {
             "authenticated": True,
+            "write_capable": bool(getattr(cred, "bili_jct", "")),
             "user": payloads.normalize_user(info),
         }
     )
     def render() -> None:
         name = info.get("name", "unknown")
         uid = info.get("mid", "unknown")
-        common.console.print(f"[green]✅ 已登录：[bold]{name}[/bold]  (UID: {uid})[/green]")
+        if getattr(cred, "bili_jct", ""):
+            common.console.print(f"[green]✅ 已登录：[bold]{name}[/bold]  (UID: {uid})[/green]")
+        else:
+            common.console.print(
+                f"[green]✅ 已登录（只读）：[bold]{name}[/bold]  (UID: {uid})；写操作需要 bili_jct[/green]"
+            )
 
     if common.emit_or_print(payload, output_format, render):
         return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,16 @@ import os
 import pytest
 from bilibili_api.utils.network import Credential
 
+import bili_cli.auth as auth
+
 os.environ.setdefault("OUTPUT", "rich")
+
+
+@pytest.fixture(autouse=True)
+def isolate_auth_storage(tmp_path, monkeypatch):
+    """Keep tests away from any real user credential file."""
+    monkeypatch.setattr(auth, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(auth, "CREDENTIAL_FILE", tmp_path / "credential.json")
 
 
 @pytest.fixture

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,10 +1,12 @@
 """Tests for auth module."""
 
+import asyncio
 import json
 import subprocess
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from bilibili_api.exceptions import NetworkException
 from bilibili_api.utils.network import Credential
 
@@ -17,6 +19,7 @@ from bili_cli.auth import (
     _validate_credential,
     clear_credential,
     get_credential,
+    qr_login,
     save_credential,
 )
 
@@ -162,7 +165,8 @@ def test_get_credential_clears_expired_saved_and_returns_none_when_browser_inval
 
 def test_get_credential_optional_uses_saved_without_validation():
     saved = Credential(sessdata="saved", bili_jct="jct")
-    with patch("bili_cli.auth._load_saved_credential", return_value=saved), \
+    with patch("bili_cli.auth._is_credential_stale", return_value=True), \
+         patch("bili_cli.auth._load_saved_credential", return_value=saved), \
          patch("bili_cli.auth._validate_credential") as mock_validate, \
          patch("bili_cli.auth._extract_browser_credential") as mock_extract:
         cred = get_credential(mode="optional")
@@ -173,11 +177,80 @@ def test_get_credential_optional_uses_saved_without_validation():
 
 def test_get_credential_write_rejects_missing_bili_jct():
     saved = Credential(sessdata="saved", bili_jct="")
-    with patch("bili_cli.auth._load_saved_credential", return_value=saved), \
-         patch("bili_cli.auth._extract_browser_credential", return_value=None), \
-         patch("bili_cli.auth._validate_credential", return_value=False):
+    with patch("bili_cli.auth._is_credential_stale", return_value=False), \
+         patch("bili_cli.auth._load_saved_credential", return_value=saved), \
+         patch("bili_cli.auth._extract_browser_credential", return_value=None) as mock_extract, \
+         patch("bili_cli.auth._validate_credential", return_value=False), \
+         patch("bili_cli.auth.clear_credential") as mock_clear:
         cred = get_credential(mode="write")
         assert cred is None
+        mock_extract.assert_called_once_with(require_write=True)
+        mock_clear.assert_not_called()
+
+
+def test_get_credential_write_rejects_indeterminate_validation():
+    saved = Credential(sessdata="saved", bili_jct="jct")
+    with patch("bili_cli.auth._is_credential_stale", return_value=False), \
+         patch("bili_cli.auth._load_saved_credential", return_value=saved), \
+         patch("bili_cli.auth._validate_credential", return_value=None), \
+         patch("bili_cli.auth._extract_browser_credential") as mock_extract:
+        assert get_credential(mode="write") is None
+        mock_extract.assert_not_called()
+
+
+def test_stale_read_refresh_does_not_clobber_write_capable_saved_credential():
+    saved = Credential(sessdata="saved", bili_jct="jct")
+    browser = Credential(sessdata="browser", bili_jct="")
+    with patch("bili_cli.auth._is_credential_stale", return_value=True), \
+         patch("bili_cli.auth._load_saved_credential", return_value=saved), \
+         patch("bili_cli.auth._extract_browser_credential", return_value=browser), \
+         patch("bili_cli.auth._validate_credential", return_value=True), \
+         patch("bili_cli.auth.save_credential") as mock_save:
+        assert get_credential(mode="read") is browser
+        mock_save.assert_not_called()
+
+
+def test_qr_login_rejects_credential_without_write_capability():
+    class DummyLogin:
+        async def generate_qrcode(self):
+            return None
+
+        async def check_state(self):
+            from bilibili_api.login_v2 import QrCodeLoginEvents
+
+            return QrCodeLoginEvents.DONE
+
+        def get_credential(self):
+            return Credential(sessdata="session", bili_jct="")
+
+    with patch("bili_cli.auth.QrCodeLogin", return_value=DummyLogin()), \
+         patch("bili_cli.auth.save_credential") as mock_save, \
+         patch("bili_cli.auth._get_qr_terminal_output", return_value="QR"):
+        with pytest.raises(RuntimeError, match="未获得可写凭证"):
+            asyncio.run(qr_login())
+        mock_save.assert_not_called()
+
+
+def test_qr_login_saves_write_capable_credential():
+    credential = Credential(sessdata="session", bili_jct="jct")
+
+    class DummyLogin:
+        async def generate_qrcode(self):
+            return None
+
+        async def check_state(self):
+            from bilibili_api.login_v2 import QrCodeLoginEvents
+
+            return QrCodeLoginEvents.DONE
+
+        def get_credential(self):
+            return credential
+
+    with patch("bili_cli.auth.QrCodeLogin", return_value=DummyLogin()), \
+         patch("bili_cli.auth.save_credential") as mock_save, \
+         patch("bili_cli.auth._get_qr_terminal_output", return_value="QR"):
+        assert asyncio.run(qr_login()) is credential
+        mock_save.assert_called_once_with(credential)
 
 
 def test_extract_browser_credential_timeout_returns_none():
@@ -195,6 +268,21 @@ def test_extract_browser_credential_empty_output_returns_none():
     fake = SimpleNamespace(returncode=0, stdout="   ", stderr="")
     with patch("bili_cli.auth.subprocess.run", return_value=fake):
         assert _extract_browser_credential() is None
+
+
+def test_extract_browser_credential_write_requires_bili_jct():
+    fake = SimpleNamespace(
+        returncode=0,
+        stdout=json.dumps({"browser": "Chrome", "cookies": {"SESSDATA": "session", "bili_jct": "jct"}}),
+        stderr="",
+    )
+    with patch("bili_cli.auth.subprocess.run", return_value=fake) as mock_run:
+        credential = _extract_browser_credential(require_write=True)
+
+    assert credential is not None
+    script = mock_run.call_args.args[0][2]
+    assert 'if cookies.get("SESSDATA") and cookies.get("bili_jct"):' in script
+    compile(script, "<browser-cookie-extractor>", "exec")
 
 
 def test_render_compact_qr_returns_multiline_text():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,17 @@ def test_status_logged_in(runner, mock_user_info):
         assert "✅" in result.output
 
 
+def test_status_reports_read_only_credential(runner, mock_user_info):
+    mock_cred = MagicMock()
+    mock_cred.bili_jct = ""
+    with patch("bili_cli.commands.common.get_credential", return_value=mock_cred), \
+         patch("bili_cli.client.get_self_info", new_callable=AsyncMock, return_value=mock_user_info):
+        result = runner.invoke(cli, ["status"])
+        assert result.exit_code == 0
+        assert "只读" in result.output
+        assert "写操作需要 bili_jct" in result.output
+
+
 def test_status_auto_yaml_when_stdout_is_not_tty(runner, mock_user_info, monkeypatch):
     monkeypatch.setenv("OUTPUT", "auto")
     mock_cred = MagicMock()
@@ -49,6 +60,7 @@ def test_status_auto_yaml_when_stdout_is_not_tty(runner, mock_user_info, monkeyp
         assert data["ok"] is True
         assert data["schema_version"] == "1"
         assert data["data"]["authenticated"] is True
+        assert data["data"]["write_capable"] is True
         assert data["data"]["user"]["name"] == "TestUP"
 
 


### PR DESCRIPTION
## Summary

- keep a saved write-capable credential when a stale read refresh only finds read-only browser cookies
- require non-empty `SESSDATA` and `bili_jct` candidates for browser-backed write operations
- fail closed when write credential validation is indeterminate, while preserving read-only credentials for diagnosis
- reject incomplete QR-login credentials before saving or reporting success
- expose `data.write_capable` and an explicit read-only status message
- isolate tests from real user credential storage

## Verification

- `pytest -q`: 209 passed, 5 deselected
- `ruff check .`: passed
- `mypy bili_cli`: passed
- `uv build`: wheel and sdist built successfully
- built wheel smoke check: `bili, version 0.6.2`
- read-only local acceptance against a temporary credential copy: authenticated=true, write_capable=true

No real login was automated and no Bilibili write operation was performed. No credential contents or account identity are included.